### PR TITLE
Replace ViroContants w/ ViroTrackingStateConstants

### DIFF
--- a/App.js
+++ b/App.js
@@ -3,7 +3,7 @@ import {StyleSheet} from 'react-native';
 import {
   ViroARScene,
   ViroText,
-  ViroConstants,
+  ViroTrackingStateConstants,
   ViroARSceneNavigator,
 } from '@viro-community/react-viro';
 
@@ -12,9 +12,9 @@ const HelloWorldSceneAR = () => {
 
   function onInitialized(state, reason) {
     console.log('guncelleme', state, reason);
-    if (state === ViroConstants.TRACKING_NORMAL) {
+    if (state === ViroTrackingStateConstants.TRACKING_NORMAL) {
       setText('Hello World!');
-    } else if (state === ViroConstants.TRACKING_NONE) {
+    } else if (state === ViroTrackingStateConstants.TRACKING_UNAVAILABLE) {
       // Handle loss of tracking
     }
   }


### PR DESCRIPTION
The enum `ViroConstants` is no longer exported by `@viro-community/react-viro`
Instead, it contains `ViroTrackingStateConstants` which seems to be the correct enum for this use case

Using `ViroConstants` leads to [this error](https://user-images.githubusercontent.com/34344402/160782308-47cfb94d-41ca-496d-b51e-ae1a4e5098c7.png) and the text on the AR scene never switches to "Hello World" from "Initializing AR..."